### PR TITLE
Make bang command shorter

### DIFF
--- a/src/bibleit/command/__init__.py
+++ b/src/bibleit/command/__init__.py
@@ -55,6 +55,8 @@ def eval(ctx, *line, module=None):
         if name in ctx.methods:
             fn = getattr(ctx.module, name)
             nargs = [normalize.normalize(arg) for arg in args]
+            if not nargs and fn.__annotations__.get("value") == bool:
+                nargs = [str(not getattr(config.flags, name))]
             return fn(ctx, *nargs)
     except AssertionError as e:
         print(f"Error: {e}")

--- a/src/bibleit/command/set.py
+++ b/src/bibleit/command/set.py
@@ -22,7 +22,7 @@ def _flag(value):
 for _flag_name in _config.flag_names:
 
     def _flag_method(name):
-        def fn(ctx, value):
+        def fn(ctx, value: bool):
             _config.set_flag(name, _flag(value))
 
         fn.__doc__ = f"Configure {_flag_name} config\n\n    set {_flag_name} <{'|'.join(_FLAGS_TOGGLE)}>"


### PR DESCRIPTION
Currently we use `set` command to set flags:

```sh
set bold true
```

And we can use bang command to be shorter:

```sh
!bold true
```

Now we can use only the command and the flag will be toggled:

```
!bold
```