### PR TITLE
Fixing make run and bible renaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ $(VENV_DIR):
 clean-venv:
 	@rm -rf $(VENV_DIR)
 
+run: ARGS?=--repl --bold
 run:
 	@(cd $(SOURCE_DIR); python -m bibleit $(ARGS))
 


### PR DESCRIPTION
When we've introduce https://github.com/mittel-labs/bibleit/pull/23, we kind of broke make run, so that, I've fixed adding default `ARGS`.

Also, renamed `ARA` translation to `ara`, in order to be standard with the other versions.