### PR TITLE
Fixing not found references

### DIFF
--- a/src/bibleit/command/core.py
+++ b/src/bibleit/command/core.py
@@ -46,9 +46,10 @@ def _ref_parse_bible(ctx, refs, term="Reference"):
 
 
 def _ref_parse(ctx, bible_fn, target, term):
-    refs = max([bible_fn(bible)(target) for bible in ctx.bible], key=len)
-    ctx.last_ref, result = refs[-1], _ref_parse_bible(ctx, refs, term)
-    return result if result else f"{term} '{' '.join(target)}' not found"
+    if refs := max([bible_fn(bible)(target) for bible in ctx.bible], key=len):
+        ctx.last_ref, result = refs[-1], _ref_parse_bible(ctx, refs, term)
+        return result
+    return f"{term} '{''.join(target)}' not found"
 
 
 def _doc(hdoc, name):


### PR DESCRIPTION
When we are search text where is not found, we are receiving an error on background due the assumption of having always a available reference.

```
✝ nvi> @dfdf
*** list index out of range

Traceback (most recent call last):
  File "/Users/fmamud/.pyenv/versions/3.11.1/lib/python3.11/site-packages/bibleit/command/__init__.py", line 63, in eval
    return fn(ctx, *nargs)
           ^^^^^^^^^^^^^^^
  File "/Users/fmamud/.pyenv/versions/3.11.1/lib/python3.11/site-packages/bibleit/command/core.py", line 121, in ref
    return _ref_parse(ctx, _attrgetter("refs"), args, "Reference")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fmamud/.pyenv/versions/3.11.1/lib/python3.11/site-packages/bibleit/command/core.py", line 50, in _ref_parse
    ctx.last_ref, result = refs[-1], _ref_parse_bible(ctx, refs, term)
                           ~~~~^^^^
IndexError: list index out of range

Search a reference(s) by chapters and verses. (alias: '@')

    ref <book> [<chapter>[:<verse[-verse]>]]

    Examples:
        ref john 1             (gets full chapter)
        ref john 1:2           (get chapter and verse)
        ref john 1:2+          (get chapter and verses with starting)
        ref john 8:31-32       (get verses range)
        ref john 8:31^2-32^2   (get verses with extra)
```